### PR TITLE
Fixed external function naming

### DIFF
--- a/client.h
+++ b/client.h
@@ -13,14 +13,14 @@
 
 #if defined(__linux__)
 extern  char  *strdup(const char *str);
-extern  int fileno(const FILE *fp);
 #endif
 
-void newRequiredMember(char *newMember);
-void freeCircleMembers();
+//  Package accessible functions
+extern void newRequiredMember(char *);
+extern void freeCircleMembers();
 
-bool uploadFile(char *fileName, bool isCert);
-bool downloadFile(char *fileName);
-void getAddress(char *hostName, int port);
-void listFiles();
-void vouchForFile(char *filename, char *certname);
+extern bool uploadFile(char *, bool);
+extern bool downloadFile(char *);
+extern getAddress(char *, int);
+extern void listFiles();
+extern void vouchForFile(char *, char *);


### PR DESCRIPTION
With external functions in .h files, the "extern" word is required at the start and don't need the variable name, only what type is expected.
I assume we'll put these functions in a separate C file (Chris loves modularity) :D
