### PR TITLE
Circle logic complete; bug fixing

### DIFF
--- a/Client/client.c
+++ b/Client/client.c
@@ -22,7 +22,7 @@ void usage(void){
 		"  -f [filename]\t\t\tFetch an existing file from the oldtrusty server.\n"
 		"  -h [hostname:port]\t\tProvide the remote address hosting the oldtrusty server.\n"
 		"  -l \t\t\t\tList all stored files and how they are protected.\n"
-		"  -n [member_name]\t\tAdd a new member to the circle of trust with \"member_name\".\n"
+		"  -n [member_name]\t\tSpecify a member you wish to be in the circle of trust with \"member_name\".\n"
 		"  -u [filename]\t\t\tUpload a certificate to the oldtrusty server.\n"
 		"  -v [filename] [certificate]\tVouch for the authenticity of an existing file on the\n"
 		"\t\t\t\toldtrusty server using the provided named certificate.\n\n", programName);

--- a/Client/client.h
+++ b/Client/client.h
@@ -29,6 +29,8 @@
 #define ACKNOWLEDGMENT 10
 #define FILE_NOT_FOUND 15
 #define FILE_FOUND 16
+#define MEMBER_REQUIRED 17
+#define MEMBER_NOT_REQUIRED 18
 /*#define PUSH 1
 #define PULL 2
 #define PUSH_CERT 3


### PR DESCRIPTION
Circle of trust logic on server is now complete. Server records
vouches, and successfully determines circles of trust, and can
successfully determine whether or not a file is trustworthy with a
given minimum circle size and required member

PULL requests now function fully, with client able to send circle size
and member name, and server servicing requests appropriately, using
circle logic to determine if file meets requirements, and acting
appropriately (server will refuse to send file if it doesn’t meet
client’s requirements)

Fixed ‘int’ communication between client and server. I thought it was
working before, but the error was just being hidden beneath the fact
that I was never actually sending ints from the client to the server. I
now use Java’s readInt() method instead of read(), and I
correspondingly wrote a sendInt() method in message.c, which sends
converts the int to a 4-byte char array and sends it (Java’s readInt()
expects a 4-byte char array)

All that’s left now is LIST, and then the project is “finished”
